### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,38 +4,20 @@ name: ci
 "on":
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is used to list changes made in each version of the remote_install coo
 ## Unreleased
 
 - resolved cookstyle error: resources/remote_install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- Require unified_mode for Chef 18 support
+- Require Chef 15.3. for unified_mode support
+- Use shared GitHub Actions workflow
+
 ## 2.1.5 - *2022-02-08*
 
 - Remove delivery folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the remote_install coo
 
 ## Unreleased
 
+- resolved cookstyle error: resources/remote_install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 2.1.5 - *2022-02-08*
 
 - Remove delivery folder

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Provides an opinionated way to download and install remote so
 version           '2.1.5'
 source_url        'https://github.com/sous-chefs/remote_install'
 issues_url        'https://github.com/sous-chefs/remote_install/issues'
-chef_version      '>= 12.7'
+chef_version      '>= 15.3'
 
 supports 'centos'
 supports 'debian'

--- a/resources/remote_install.rb
+++ b/resources/remote_install.rb
@@ -18,6 +18,7 @@
 #
 
 provides :remote_install
+unified_mode true
 
 property :source,            String, required: true
 property :version,           String, required: true

--- a/resources/remote_install.rb
+++ b/resources/remote_install.rb
@@ -30,7 +30,7 @@ property :install_command,   String, required: true
 property :environment,       Hash,   default: {}
 property :extract_basename,  String, default: lazy { |r| "#{r.name}-#{r.version}" }
 
-action(:install) do
+action :install do
   converge_by("Install #{new_resource}") do
     download
     verify


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.31.7 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/remote_install.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)